### PR TITLE
Add basic travel planner with map and route optimization

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Travel Planner</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="route.js"></script>
+</head>
+<body>
+  <div id="sidebar">
+    <h2>Trip Planner</h2>
+    <input id="location-input" type="text" placeholder="Add location" />
+    <button id="add-btn">Add Location</button>
+    <button id="opt-btn">Optimize Route</button>
+    <ul id="location-list"></ul>
+  </div>
+  <div id="map"></div>
+  <script>
+    const map = L.map('map').setView([20,0], 2);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+
+    const markers = [];
+    let routeLine = null;
+
+    function addMarker(loc) {
+      const marker = L.marker([loc.lat, loc.lng]).addTo(map).bindPopup(loc.name || 'Location');
+      markers.push({ marker, loc });
+      const li = document.createElement('li');
+      li.textContent = loc.name || `${loc.lat.toFixed(3)}, ${loc.lng.toFixed(3)}`;
+      document.getElementById('location-list').appendChild(li);
+      if (markers.length === 1) marker.bindPopup('Hotel (Start)').openPopup();
+    }
+
+    async function geocode(query) {
+      const res = await fetch(`https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(query)}`);
+      const data = await res.json();
+      return data[0] ? { lat: parseFloat(data[0].lat), lng: parseFloat(data[0].lon), name: data[0].display_name } : null;
+    }
+
+    document.getElementById('add-btn').onclick = async () => {
+      const query = document.getElementById('location-input').value.trim();
+      if (!query) return;
+      const loc = await geocode(query);
+      if (loc) {
+        addMarker(loc);
+        map.setView([loc.lat, loc.lng], 13);
+      }
+      document.getElementById('location-input').value = '';
+    };
+
+    document.getElementById('opt-btn').onclick = () => {
+      if (markers.length < 2) return;
+      const locs = markers.map(m => ({ lat: m.loc.lat, lng: m.loc.lng }));
+      const route = optimizeRoute(locs);
+      if (routeLine) routeLine.remove();
+      const latlngs = route.map(p => [p.lat, p.lng]);
+      routeLine = L.polyline(latlngs, { color: 'blue' }).addTo(map);
+      map.fitBounds(routeLine.getBounds());
+    };
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "travel-app",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node route.test.js"
+  }
+}

--- a/route.js
+++ b/route.js
@@ -1,0 +1,39 @@
+function haversine(a, b) {
+  const R = 6371; // Earth radius in km
+  const toRad = deg => deg * Math.PI / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const h = Math.sin(dLat / 2) ** 2 + Math.sin(dLng / 2) ** 2 * Math.cos(lat1) * Math.cos(lat2);
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+function optimizeRoute(locations) {
+  if (!locations || locations.length === 0) return [];
+  const remaining = locations.slice(1);
+  const route = [locations[0]];
+  let current = locations[0];
+  while (remaining.length) {
+    let nearestIndex = 0;
+    let nearestDist = haversine(current, remaining[0]);
+    for (let i = 1; i < remaining.length; i++) {
+      const d = haversine(current, remaining[i]);
+      if (d < nearestDist) {
+        nearestDist = d;
+        nearestIndex = i;
+      }
+    }
+    current = remaining.splice(nearestIndex, 1)[0];
+    route.push(current);
+  }
+  return route;
+}
+
+if (typeof window !== 'undefined') {
+  window.optimizeRoute = optimizeRoute;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { optimizeRoute };
+}

--- a/route.test.js
+++ b/route.test.js
@@ -1,0 +1,13 @@
+const assert = require('assert');
+const { optimizeRoute } = require('./route.js');
+
+const locations = [
+  { lat: 0, lng: 0 }, // start
+  { lat: 0, lng: 2 },
+  { lat: 0, lng: 1 }
+];
+
+const route = optimizeRoute(locations);
+assert.strictEqual(route.length, 3);
+assert.deepStrictEqual(route.map(p => p.lng), [0, 1, 2]);
+console.log('route optimization test passed');

--- a/style.css
+++ b/style.css
@@ -1,0 +1,14 @@
+body, html { height: 100%; margin: 0; font-family: Arial, sans-serif; }
+#map { height: 100%; }
+#sidebar {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 1000;
+  background: rgba(255,255,255,0.9);
+  padding: 10px;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+}
+#location-list { list-style: none; padding: 0; max-height: 200px; overflow-y: auto; }
+#location-list li { margin: 4px 0; }


### PR DESCRIPTION
## Summary
- Add Leaflet-based map interface to add locations and optimize travel route.
- Implement nearest-neighbor route optimization and geocoding.
- Include basic styles and a simple Node test for route algorithm.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b55388f1a48332a5b35be590bb4923