### PR TITLE
Add simple interactive travel planner

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Travel Planner</title>
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-sA+e2NvES0+gDdGkvyYOnWfwQ78S6B8ij9kAdKo0L0k="
+    crossorigin=""/>
+  <style>
+    body {
+      margin: 0;
+      font-family: Arial, sans-serif;
+      height: 100vh;
+    }
+    #map {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      right: 0;
+      left: 30%;
+      height: 100vh;
+    }
+    #panel {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      width: 30%;
+      background: #f8f9fa;
+      padding: 1rem;
+      box-sizing: border-box;
+      overflow-y: auto;
+      box-shadow: 2px 0 5px rgba(0,0,0,0.1);
+    }
+    h1 {
+      margin-top: 0;
+    }
+    button {
+      margin: 0.25rem 0;
+      width: 100%;
+      padding: 0.5rem;
+      font-size: 1rem;
+      cursor: pointer;
+    }
+    input[type="text"] {
+      width: 100%;
+      padding: 0.4rem;
+      margin: 0.25rem 0;
+      box-sizing: border-box;
+    }
+    ol {
+      padding-left: 1.2rem;
+    }
+  </style>
+</head>
+<body>
+<div id="panel">
+  <h1>Trip Planner</h1>
+  <p>Enter addresses to set your hotel and stops. Searches are optimized for Japan. Click "Optimize Route" to see the suggested path.</p>
+  <input type="text" id="hotelInput" placeholder="Hotel address" />
+  <button id="hotelBtn">Set Hotel</button>
+  <input type="text" id="locInput" placeholder="Add stop address" />
+  <button id="locBtn">Add Location</button>
+  <button id="optBtn">Optimize Route</button>
+  <h2>Stops</h2>
+  <ol id="stops"></ol>
+</div>
+<div id="map"></div>
+<script
+  src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+  integrity="sha256-Vt7A4SxC51K1g65w8Br1Fyf7tRIXmGfHP5QnUWmUh5M="
+  crossorigin="">
+</script>
+<script>
+  const map = L.map('map').setView([36.2048, 138.2529], 5); // center on Japan
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '&copy; <a href="https://www.openstreetmap.org/">OSM</a>'
+  }).addTo(map);
+
+  let hotelMarker = null;
+  const locationMarkers = [];
+  const locations = []; // {lat,lng,name}
+  let routeLine = null;
+
+  const stopsList = document.getElementById('stops');
+  const hotelInput = document.getElementById('hotelInput');
+  const locInput = document.getElementById('locInput');
+
+  document.getElementById('hotelBtn').onclick = setHotel;
+  document.getElementById('locBtn').onclick = addLocation;
+  document.getElementById('optBtn').onclick = optimizeRoute;
+
+  async function geocode(query) {
+    const url = `https://nominatim.openstreetmap.org/search?format=json&limit=1&countrycodes=jp&accept-language=ja&q=${encodeURIComponent(query)}`;
+    const res = await fetch(url);
+    const data = await res.json();
+    if (!data[0]) throw new Error('not found');
+    return { lat: parseFloat(data[0].lat), lng: parseFloat(data[0].lon), name: data[0].display_name };
+  }
+
+  async function setHotel() {
+    const addr = hotelInput.value.trim();
+    if (!addr) { alert('Please enter a hotel address.'); return; }
+    try {
+      const p = await geocode(addr);
+      if (hotelMarker) map.removeLayer(hotelMarker);
+      hotelMarker = L.marker(p, {icon: L.icon({
+        iconUrl: 'https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/images/marker-icon.png',
+        iconSize: [25,41], iconAnchor:[12,41],
+        popupAnchor:[1,-34], shadowSize:[41,41]
+      })}).addTo(map).bindPopup('Hotel').openPopup();
+      map.setView(p, 13);
+    } catch (e) {
+      alert('Hotel address not found.');
+    }
+  }
+
+  async function addLocation() {
+    const addr = locInput.value.trim();
+    if (!addr) { alert('Please enter a stop address.'); return; }
+    try {
+      const p = await geocode(addr);
+      const marker = L.marker(p).addTo(map).bindPopup('Stop '+(locations.length+1));
+      locationMarkers.push(marker);
+      locations.push(p);
+      const li = document.createElement('li');
+      li.textContent = p.name;
+      stopsList.appendChild(li);
+      locInput.value = '';
+      map.setView(p, 13);
+    } catch (e) {
+      alert('Location not found.');
+    }
+  }
+
+  function distance(a, b) {
+    const R = 6371; // km
+    const dLat = (b.lat - a.lat) * Math.PI / 180;
+    const dLng = (b.lng - a.lng) * Math.PI / 180;
+    const lat1 = a.lat * Math.PI / 180;
+    const lat2 = b.lat * Math.PI / 180;
+    const sinDLat = Math.sin(dLat/2);
+    const sinDLng = Math.sin(dLng/2);
+    const c = 2 * Math.asin(Math.sqrt(sinDLat*sinDLat + Math.cos(lat1)*Math.cos(lat2)*sinDLng*sinDLng));
+    return R * c;
+  }
+
+  function nearestNeighbor(start, pts) {
+    const remaining = pts.slice();
+    const route = [];
+    let current = start;
+    while (remaining.length) {
+      let idx = 0;
+      let best = Infinity;
+      remaining.forEach((p,i) => {
+        const d = distance(current,p);
+        if (d < best) { best = d; idx = i; }
+      });
+      current = remaining.splice(idx,1)[0];
+      route.push(current);
+    }
+    return route;
+  }
+
+  function optimizeRoute() {
+    if (!hotelMarker) {
+      alert('Please set the hotel location first.');
+      return;
+    }
+    if (locations.length === 0) {
+      alert('Please add at least one stop.');
+      return;
+    }
+    const hotel = hotelMarker.getLatLng();
+    const ordered = nearestNeighbor(hotel, locations);
+    const latlngs = [hotel, ...ordered];
+
+    if (routeLine) map.removeLayer(routeLine);
+    routeLine = L.polyline(latlngs, {color: 'blue'}).addTo(map);
+
+    // update list to show order
+    stopsList.innerHTML = '';
+    ordered.forEach((p,i) => {
+      const li = document.createElement('li');
+      li.textContent = `Stop ${i+1}: ${p.name}`;
+      stopsList.appendChild(li);
+    });
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add Japanese address search to set hotel and stops
- Center map on Japan and replace map clicks with geocoded inputs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b55388f1a48332a5b35be590bb4923